### PR TITLE
Update Documentation and Create Midi Mapping for MA2 import

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ import "MA2_Keyboard" at remote 2
 ***NOTE***: If you already have midi mapping setup in your showfile, make sure there are no collisions of midi note numbers.
 
 ## Setup in GrandMA2 onPC
-You need to set the "Note" value in GrandMA2's Remote Input Settings to the 
+You need to set the "Note" value in GrandMA2's Remote Input Setting to the following table
 
 |Midi Number|Key|
 |--|-----------|
@@ -119,40 +119,42 @@ You need to set the "Note" value in GrandMA2's Remote Input Settings to the
 |28|Cue        |
 |29|Exec       |
 |30|Go -       |
-|31|Go +       |
-|32|Channel    |
-|33|Fixture    |
-|34|Group      |
-|35|Move       |
-|36|Time       |
-|37|Esc        |
-|38|7          |
-|39|8          |
-|40|9          |
-|41|+          |
-|42|Full       |
-|43|Highlight  |
-|44|Solo       |
-|45|Edit       |
-|46|Oops       |
-|47|4          |
-|48|5          |
-|49|6          |
-|50|Thru       |
-|51|1          |
-|52|2          |
-|53|3          |
-|54|Up         |
-|55|Update     |
-|56|Clear      |
-|57|0          |
-|58|. (Dot)    |
-|59|If         |
-|60|At         |
-|61|Previous   |
-|62|Set        |
-|63|Next       |
-|64|Store      |
-|65|MA         |
-|66|Please     |
-|67|Down       |
+|31|Pause      |
+|32|Go +       |
+|33|Channel    |
+|34|Fixture    |
+|35|Group      |
+|36|Move       |
+|37|Time       |
+|38|Esc        |
+|39|7          |
+|40|8          |
+|41|9          |
+|42|+          |
+|43|Full       |
+|44|Highlight  |
+|45|Solo       |
+|46|Edit       |
+|47|Oops       |
+|48|4          |
+|49|5          |
+|50|6          |
+|51|Thru       |
+|52|1          |
+|53|2          |
+|54|3          |
+|55|-          |
+|56|Up         |
+|57|Update     |
+|58|Clear      |
+|59|0          |
+|60|. (Dot)    |
+|61|If         |
+|62|At         |
+|63|Previous   |
+|64|Set        |
+|65|Next       |
+|66|Store      |
+|67|MA         |
+|68|Please     |
+|69|Down       |

--- a/README.md
+++ b/README.md
@@ -77,28 +77,82 @@ The firmware is written using [KMK](http://kmkfw.io).
 ### Midi:
 The midi notes need to be mapped new in every different showfile!
 
+To import the midi mappings into your showfile, copy the [MA2_Keyboard.xml](https://github.com/hartmann-jonas/GrandMA2-Keyboard/blob/main/midi-mapping/MA2_Keyboard.xml) into your `importexport` folder of your GrandMA2 install and run the import command
+```
+import "MA2_Keyboard" at remote 2
+```
+***NOTE***: If you already have midi mapping setup in your showfile, make sure there are no collisions of midi note numbers.
 
 ## Setup in GrandMA2 onPC
 You need to set the "Note" value in GrandMA2's Remote Input Settings to the 
 
-|Midi Number|Key|Midi Number|Key|Midi Number|Key|Midi Number|Key|
-|--|-----------|--|------------|--|------------|--|------------|
-|0|Encoder Key |19|On          |38|7           |57|0
-|1|Tools       |20|Page        |39|8           |58|. (Dot)
-|2|Setup       |21|Macro       |40|9           |59|If
-|3|Backup      |22|Preset      |41|+           |60|At
-|4|Help        |23|Copy        |42|Full        |61|Previous
-|5|Blind       |24|<<<         |43|Highlight   |62|Set
-|6|Freeze      |25|Learn       |44|Solo        |63|Next
-|7|Preview     |26|>>>         |45|Edit        |64|Store
-|8|Assign      |27|Sequ        |46|Oops        |65|MA
-|9|Align       |28|Cue         |47|4           |66|Please
-|10|Fix        |29|Exec        |48|5           |67|Down
-|11|Select     |30|Go -        |49|6
-|12|Off        |31|Go +        |50|Thru
-|13|View       |32|Channel     |51|1
-|14|Effect     |33|Fixture     |52|2
-|15|Goto       |34|Group       |53|3
-|16|Del        |35|Move        |54|Up
-|17|Temp       |36|Time        |55|Update
-|18|Top        |37|Esc         |56|Clear
+|Midi Number|Key|
+|--|-----------|
+|0|Encoder Key |
+|1|Tools       |
+|2|Setup       |
+|3|Backup      |
+|4|Help        |
+|5|Blind       |
+|6|Freeze      |
+|7|Preview     |
+|8|Assign      |
+|9|Align       |
+|10|Fix        |
+|11|Select     |
+|12|Off        |
+|13|View       |
+|14|Effect     |
+|15|Goto       |
+|16|Del        |
+|17|Temp       |
+|18|Top        |
+|19|On         |
+|20|Page       |
+|21|Macro      |
+|22|Preset     |
+|23|Copy       |
+|24|<<<        |
+|25|Learn      |
+|26|>>>        |
+|27|Sequ       |
+|28|Cue        |
+|29|Exec       |
+|30|Go -       |
+|31|Go +       |
+|32|Channel    |
+|33|Fixture    |
+|34|Group      |
+|35|Move       |
+|36|Time       |
+|37|Esc        |
+|38|7          |
+|39|8          |
+|40|9          |
+|41|+          |
+|42|Full       |
+|43|Highlight  |
+|44|Solo       |
+|45|Edit       |
+|46|Oops       |
+|47|4          |
+|48|5          |
+|49|6          |
+|50|Thru       |
+|51|1          |
+|52|2          |
+|53|3          |
+|54|Up         |
+|55|Update     |
+|56|Clear      |
+|57|0          |
+|58|. (Dot)    |
+|59|If         |
+|60|At         |
+|61|Previous   |
+|62|Set        |
+|63|Next       |
+|64|Store      |
+|65|MA         |
+|66|Please     |
+|67|Down       |

--- a/midi-mapping/MA2_Keyboard.xml
+++ b/midi-mapping/MA2_Keyboard.xml
@@ -1,0 +1,356 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<MA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.malighting.de/grandma2/xml/MA" xsi:schemaLocation="http://schemas.malighting.de/grandma2/xml/MA http://schemas.malighting.de/grandma2/xml/3.9.60/MA.xsd" major_vers="3" minor_vers="9" stream_vers="60">
+	<Info datetime="2023-08-23T00:00:00" showfile="ma2 keyboard midi export" />
+	<MidiRemotes index="1">
+		<RemoteMidi index="1" note="29" channel="3" type="hardkey" tasten_code="Executor">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="2" note="30" channel="3" type="hardkey" tasten_code="GoMinus">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="3" note="31" channel="3" type="hardkey" tasten_code="GoPlus">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="4" note="10" channel="3" type="hardkey" tasten_code="Fix">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="5" note="11" channel="3" type="hardkey" tasten_code="Select">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="6" note="12" channel="3" type="hardkey" tasten_code="Off">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="7" note="17" channel="3" type="hardkey" tasten_code="Temp">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="8" note="19" channel="3" type="hardkey" tasten_code="On">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="9" note="25" channel="3" type="hardkey" tasten_code="Learn">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="10" note="46" channel="3" type="hardkey" tasten_code="Oops">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="11" note="45" channel="3" type="hardkey" tasten_code="Edit">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="12" note="15" channel="3" type="hardkey" tasten_code="Goto">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="13" note="55" channel="3" type="hardkey" tasten_code="Update">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="14" note="36" channel="3" type="hardkey" tasten_code="Time">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="15" note="64" channel="3" type="hardkey" tasten_code="Store">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="16" note="5" channel="3" type="hardkey" tasten_code="Blind">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="17" note="6" channel="3" type="hardkey" tasten_code="Freeze">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="18" note="7" channel="3" type="hardkey" tasten_code="Preview">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="19" note="8" channel="3" type="hardkey" tasten_code="Assign">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="20" note="9" channel="3" type="hardkey" tasten_code="Align">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="21" note="13" channel="3" type="hardkey" tasten_code="View">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="22" note="14" channel="3" type="hardkey" tasten_code="Effect">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="23" note="65" channel="3" type="hardkey" tasten_code="MA">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="24" note="16" channel="3" type="hardkey" tasten_code="Delete">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="25" note="20" channel="3" type="hardkey" tasten_code="Page">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="26" note="21" channel="3" type="hardkey" tasten_code="Macro">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="27" note="22" channel="3" type="hardkey" tasten_code="Preset">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="28" note="23" channel="3" type="hardkey" tasten_code="Copy">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="29" note="27" channel="3" type="hardkey" tasten_code="Sequence">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="30" note="28" channel="3" type="hardkey" tasten_code="Cue">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="31" note="32" channel="3" type="hardkey" tasten_code="Channel">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="32" note="33" channel="3" type="hardkey" tasten_code="Fixture">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="33" note="34" channel="3" type="hardkey" tasten_code="Group">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="34" note="35" channel="3" type="hardkey" tasten_code="Move">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="36" note="57" channel="3" type="hardkey" tasten_code="0">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="37" note="51" channel="3" type="hardkey" tasten_code="1">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="38" note="52" channel="3" type="hardkey" tasten_code="2">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="39" note="53" channel="3" type="hardkey" tasten_code="3">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="40" note="47" channel="3" type="hardkey" tasten_code="4">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="41" note="48" channel="3" type="hardkey" tasten_code="5">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="42" note="49" channel="3" type="hardkey" tasten_code="6">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="43" note="38" channel="3" type="hardkey" tasten_code="7">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="44" note="39" channel="3" type="hardkey" tasten_code="8">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="45" note="40" channel="3" type="hardkey" tasten_code="9">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="46" note="41" channel="3" type="hardkey" tasten_code="Plus">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<!-- <RemoteMidi index="47" note="60" channel="3" type="hardkey" tasten_code="Minus">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi> -->
+		<RemoteMidi index="48" note="58" channel="3" type="hardkey" tasten_code="Dot">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="49" note="42" channel="3" type="hardkey" tasten_code="Full">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="50" note="43" channel="3" type="hardkey" tasten_code="Highlight">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="51" note="44" channel="3" type="hardkey" tasten_code="Solo">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="52" note="50" channel="3" type="hardkey" tasten_code="Thru">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="53" note="59" channel="3" type="hardkey" tasten_code="If">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="54" note="60" channel="3" type="hardkey" tasten_code="At">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="55" note="56" channel="3" type="hardkey" tasten_code="Clear">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="56" note="66" channel="3" type="hardkey" tasten_code="Please">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="57" note="54" channel="3" type="hardkey" tasten_code="Up">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="58" note="67" channel="3" type="hardkey" tasten_code="Down">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="59" note="62" channel="3" type="hardkey" tasten_code="Set">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="60" note="61" channel="3" type="hardkey" tasten_code="Previous">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="61" note="63" channel="3" type="hardkey" tasten_code="Next">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="62" note="3" channel="3" type="hardkey" tasten_code="Backup">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="63" note="2" channel="3" type="hardkey" tasten_code="Setup">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="64" channel="1" type="hardkey" tasten_code="Tools">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="65" note="18" channel="3" type="hardkey" tasten_code="Top">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="66" note="24" channel="3" type="hardkey" tasten_code="&lt;&lt;&lt;">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="67" note="26" channel="3" type="hardkey" tasten_code="&gt;&gt;&gt;">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="68" note="0" channel="3" type="hardkey" tasten_code="Encoder">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="69" note="37" channel="3" type="hardkey" tasten_code="Escape">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="70" note="1" channel="3" type="hardkey" tasten_code="Escape">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="71" note="4" channel="3" type="hardkey" tasten_code="Tools">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+	</MidiRemotes>
+</MA>

--- a/midi-mapping/MA2_Keyboard.xml
+++ b/midi-mapping/MA2_Keyboard.xml
@@ -2,252 +2,257 @@
 <MA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.malighting.de/grandma2/xml/MA" xsi:schemaLocation="http://schemas.malighting.de/grandma2/xml/MA http://schemas.malighting.de/grandma2/xml/3.9.60/MA.xsd" major_vers="3" minor_vers="9" stream_vers="60">
 	<Info datetime="2023-08-23T00:00:00" showfile="ma2 keyboard midi export" />
 	<MidiRemotes index="1">
-		<RemoteMidi index="1" note="29" channel="3" type="hardkey" tasten_code="Executor">
+		<RemoteMidi index="1" note="0" channel="3" type="hardkey" tasten_code="Encoder">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="2" note="30" channel="3" type="hardkey" tasten_code="GoMinus">
+		<RemoteMidi index="2" note="1" channel="3" type="hardkey" tasten_code="Tools">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="3" note="32" channel="3" type="hardkey" tasten_code="GoPlus">
+		<RemoteMidi index="3" note="2" channel="3" type="hardkey" tasten_code="Setup">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="4" note="10" channel="3" type="hardkey" tasten_code="Fix">
+		<RemoteMidi index="4" note="3" channel="3" type="hardkey" tasten_code="Backup">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="5" note="11" channel="3" type="hardkey" tasten_code="Select">
+		<RemoteMidi index="5" note="4" channel="3" type="hardkey" tasten_code="Help">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="6" note="12" channel="3" type="hardkey" tasten_code="Off">
+		<RemoteMidi index="6" note="5" channel="3" type="hardkey" tasten_code="Blind">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="7" note="17" channel="3" type="hardkey" tasten_code="Temp">
+		<RemoteMidi index="7" note="6" channel="3" type="hardkey" tasten_code="Freeze">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="8" note="19" channel="3" type="hardkey" tasten_code="On">
+		<RemoteMidi index="8" note="7" channel="3" type="hardkey" tasten_code="Preview">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="9" note="25" channel="3" type="hardkey" tasten_code="Learn">
+		<RemoteMidi index="9" note="8" channel="3" type="hardkey" tasten_code="Assign">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="10" note="47" channel="3" type="hardkey" tasten_code="Oops">
+		<RemoteMidi index="10" note="9" channel="3" type="hardkey" tasten_code="Align">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="11" note="46" channel="3" type="hardkey" tasten_code="Edit">
+		<RemoteMidi index="11" note="10" channel="3" type="hardkey" tasten_code="Fix">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="12" note="15" channel="3" type="hardkey" tasten_code="Goto">
+		<RemoteMidi index="12" note="11" channel="3" type="hardkey" tasten_code="Select">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="13" note="57" channel="3" type="hardkey" tasten_code="Update">
+		<RemoteMidi index="13" note="12" channel="3" type="hardkey" tasten_code="Off">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="14" note="37" channel="3" type="hardkey" tasten_code="Time">
+		<RemoteMidi index="14" note="13" channel="3" type="hardkey" tasten_code="View">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="15" note="66" channel="3" type="hardkey" tasten_code="Store">
+		<RemoteMidi index="15" note="14" channel="3" type="hardkey" tasten_code="Effect">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="16" note="5" channel="3" type="hardkey" tasten_code="Blind">
+		<RemoteMidi index="16" note="15" channel="3" type="hardkey" tasten_code="Goto">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="17" note="6" channel="3" type="hardkey" tasten_code="Freeze">
+		<RemoteMidi index="17" note="16" channel="3" type="hardkey" tasten_code="Delete">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="18" note="7" channel="3" type="hardkey" tasten_code="Preview">
+		<RemoteMidi index="18" note="17" channel="3" type="hardkey" tasten_code="Temp">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="19" note="8" channel="3" type="hardkey" tasten_code="Assign">
+		<RemoteMidi index="19" note="18" channel="3" type="hardkey" tasten_code="Top">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="20" note="9" channel="3" type="hardkey" tasten_code="Align">
+		<RemoteMidi index="20" note="19" channel="3" type="hardkey" tasten_code="On">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="21" note="13" channel="3" type="hardkey" tasten_code="View">
+		<RemoteMidi index="21" note="20" channel="3" type="hardkey" tasten_code="Page">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="22" note="14" channel="3" type="hardkey" tasten_code="Effect">
+		<RemoteMidi index="22" note="21" channel="3" type="hardkey" tasten_code="Macro">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="23" note="67" channel="3" type="hardkey" tasten_code="MA">
+		<RemoteMidi index="23" note="22" channel="3" type="hardkey" tasten_code="Preset">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="24" note="16" channel="3" type="hardkey" tasten_code="Delete">
+		<RemoteMidi index="24" note="23" channel="3" type="hardkey" tasten_code="Copy">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="25" note="20" channel="3" type="hardkey" tasten_code="Page">
+		<RemoteMidi index="25" note="24" channel="3" type="hardkey" tasten_code="&lt;&lt;&lt;">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="26" note="21" channel="3" type="hardkey" tasten_code="Macro">
+		<RemoteMidi index="26" note="25" channel="3" type="hardkey" tasten_code="Learn">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="27" note="22" channel="3" type="hardkey" tasten_code="Preset">
+		<RemoteMidi index="27" note="26" channel="3" type="hardkey" tasten_code="&gt;&gt;&gt;">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="28" note="23" channel="3" type="hardkey" tasten_code="Copy">
+		<RemoteMidi index="28" note="27" channel="3" type="hardkey" tasten_code="Sequence">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="29" note="27" channel="3" type="hardkey" tasten_code="Sequence">
+		<RemoteMidi index="29" note="28" channel="3" type="hardkey" tasten_code="Cue">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="30" note="28" channel="3" type="hardkey" tasten_code="Cue">
+		<RemoteMidi index="30" note="29" channel="3" type="hardkey" tasten_code="Executor">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="31" note="33" channel="3" type="hardkey" tasten_code="Channel">
+		<RemoteMidi index="31" note="30" channel="3" type="hardkey" tasten_code="GoMinus">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="32" note="34" channel="3" type="hardkey" tasten_code="Fixture">
+		<RemoteMidi index="32" note="31" channel="3" type="hardkey" tasten_code="Pause">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="33" note="35" channel="3" type="hardkey" tasten_code="Group">
+		<RemoteMidi index="33" note="32" channel="3" type="hardkey" tasten_code="GoPlus">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="34" note="36" channel="3" type="hardkey" tasten_code="Move">
+		<RemoteMidi index="34" note="33" channel="3" type="hardkey" tasten_code="Channel">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="36" note="59" channel="3" type="hardkey" tasten_code="0">
+		<RemoteMidi index="35" note="34" channel="3" type="hardkey" tasten_code="Fixture">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="37" note="52" channel="3" type="hardkey" tasten_code="1">
+		<RemoteMidi index="36" note="35" channel="3" type="hardkey" tasten_code="Group">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="38" note="53" channel="3" type="hardkey" tasten_code="2">
+		<RemoteMidi index="37" note="36" channel="3" type="hardkey" tasten_code="Move">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="39" note="54" channel="3" type="hardkey" tasten_code="3">
+		<RemoteMidi index="38" note="37" channel="3" type="hardkey" tasten_code="Time">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="40" note="48" channel="3" type="hardkey" tasten_code="4">
+		<RemoteMidi index="39" note="38" channel="3" type="hardkey" tasten_code="Escape">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="41" note="49" channel="3" type="hardkey" tasten_code="5">
+		<RemoteMidi index="40" note="39" channel="3" type="hardkey" tasten_code="7">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="42" note="50" channel="3" type="hardkey" tasten_code="6">
+		<RemoteMidi index="41" note="40" channel="3" type="hardkey" tasten_code="8">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="43" note="39" channel="3" type="hardkey" tasten_code="7">
+		<RemoteMidi index="42" note="41" channel="3" type="hardkey" tasten_code="9">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="44" note="40" channel="3" type="hardkey" tasten_code="8">
+		<RemoteMidi index="43" note="42" channel="3" type="hardkey" tasten_code="Plus">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="45" note="41" channel="3" type="hardkey" tasten_code="9">
+		<RemoteMidi index="44" note="43" channel="3" type="hardkey" tasten_code="Full">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="46" note="42" channel="3" type="hardkey" tasten_code="Plus">
+		<RemoteMidi index="45" note="44" channel="3" type="hardkey" tasten_code="Highlight">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="47" note="55" channel="3" type="hardkey" tasten_code="Minus">
+		<RemoteMidi index="46" note="45" channel="3" type="hardkey" tasten_code="Solo">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="48" note="60" channel="3" type="hardkey" tasten_code="Dot">
+		<RemoteMidi index="47" note="46" channel="3" type="hardkey" tasten_code="Edit">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="49" note="43" channel="3" type="hardkey" tasten_code="Full">
+		<RemoteMidi index="48" note="47" channel="3" type="hardkey" tasten_code="Oops">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="50" note="44" channel="3" type="hardkey" tasten_code="Highlight">
+		<RemoteMidi index="49" note="48" channel="3" type="hardkey" tasten_code="4">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="51" note="45" channel="3" type="hardkey" tasten_code="Solo">
+		<RemoteMidi index="50" note="49" channel="3" type="hardkey" tasten_code="5">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="51" note="50" channel="3" type="hardkey" tasten_code="6">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
@@ -257,22 +262,22 @@
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="53" note="61" channel="3" type="hardkey" tasten_code="If">
+		<RemoteMidi index="53" note="52" channel="3" type="hardkey" tasten_code="1">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="54" note="62" channel="3" type="hardkey" tasten_code="At">
+		<RemoteMidi index="54" note="53" channel="3" type="hardkey" tasten_code="2">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="55" note="58" channel="3" type="hardkey" tasten_code="Clear">
+		<RemoteMidi index="55" note="54" channel="3" type="hardkey" tasten_code="3">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="56" note="68" channel="3" type="hardkey" tasten_code="Please">
+		<RemoteMidi index="56" note="55" channel="3" type="hardkey" tasten_code="Minus">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
@@ -282,67 +287,67 @@
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="58" note="69" channel="3" type="hardkey" tasten_code="Down">
+		<RemoteMidi index="58" note="57" channel="3" type="hardkey" tasten_code="Update">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="59" note="64" channel="3" type="hardkey" tasten_code="Set">
+		<RemoteMidi index="59" note="58" channel="3" type="hardkey" tasten_code="Clear">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="60" note="63" channel="3" type="hardkey" tasten_code="Previous">
+		<RemoteMidi index="60" note="59" channel="3" type="hardkey" tasten_code="0">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="61" note="65" channel="3" type="hardkey" tasten_code="Next">
+		<RemoteMidi index="61" note="60" channel="3" type="hardkey" tasten_code="Dot">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="62" note="3" channel="3" type="hardkey" tasten_code="Backup">
+		<RemoteMidi index="62" note="61" channel="3" type="hardkey" tasten_code="If">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="63" note="2" channel="3" type="hardkey" tasten_code="Setup">
+		<RemoteMidi index="63" note="62" channel="3" type="hardkey" tasten_code="At">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="64" note="1" channel="3" type="hardkey" tasten_code="Tools">
+		<RemoteMidi index="64" note="63" channel="3" type="hardkey" tasten_code="Previous">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="65" note="18" channel="3" type="hardkey" tasten_code="Top">
+		<RemoteMidi index="65" note="64" channel="3" type="hardkey" tasten_code="Set">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="66" note="24" channel="3" type="hardkey" tasten_code="&lt;&lt;&lt;">
+		<RemoteMidi index="66" note="65" channel="3" type="hardkey" tasten_code="Next">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="67" note="26" channel="3" type="hardkey" tasten_code="&gt;&gt;&gt;">
+		<RemoteMidi index="67" note="66" channel="3" type="hardkey" tasten_code="Store">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="68" note="0" channel="3" type="hardkey" tasten_code="Encoder">
+		<RemoteMidi index="68" note="67" channel="3" type="hardkey" tasten_code="MA">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="69" note="38" channel="3" type="hardkey" tasten_code="Escape">
+		<RemoteMidi index="69" note="68" channel="3" type="hardkey" tasten_code="Please">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="70" note="31" channel="3" type="hardkey" tasten_code="Pause">
+		<RemoteMidi index="70" note="69" channel="3" type="hardkey" tasten_code="Down">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>

--- a/midi-mapping/MA2_Keyboard.xml
+++ b/midi-mapping/MA2_Keyboard.xml
@@ -12,7 +12,7 @@
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="3" note="31" channel="3" type="hardkey" tasten_code="GoPlus">
+		<RemoteMidi index="3" note="32" channel="3" type="hardkey" tasten_code="GoPlus">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
@@ -47,12 +47,12 @@
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="10" note="46" channel="3" type="hardkey" tasten_code="Oops">
+		<RemoteMidi index="10" note="47" channel="3" type="hardkey" tasten_code="Oops">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="11" note="45" channel="3" type="hardkey" tasten_code="Edit">
+		<RemoteMidi index="11" note="46" channel="3" type="hardkey" tasten_code="Edit">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
@@ -62,17 +62,17 @@
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="13" note="55" channel="3" type="hardkey" tasten_code="Update">
+		<RemoteMidi index="13" note="57" channel="3" type="hardkey" tasten_code="Update">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="14" note="36" channel="3" type="hardkey" tasten_code="Time">
+		<RemoteMidi index="14" note="37" channel="3" type="hardkey" tasten_code="Time">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="15" note="64" channel="3" type="hardkey" tasten_code="Store">
+		<RemoteMidi index="15" note="66" channel="3" type="hardkey" tasten_code="Store">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
@@ -112,7 +112,7 @@
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="23" note="65" channel="3" type="hardkey" tasten_code="MA">
+		<RemoteMidi index="23" note="67" channel="3" type="hardkey" tasten_code="MA">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
@@ -152,152 +152,152 @@
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="31" note="32" channel="3" type="hardkey" tasten_code="Channel">
+		<RemoteMidi index="31" note="33" channel="3" type="hardkey" tasten_code="Channel">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="32" note="33" channel="3" type="hardkey" tasten_code="Fixture">
+		<RemoteMidi index="32" note="34" channel="3" type="hardkey" tasten_code="Fixture">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="33" note="34" channel="3" type="hardkey" tasten_code="Group">
+		<RemoteMidi index="33" note="35" channel="3" type="hardkey" tasten_code="Group">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="34" note="35" channel="3" type="hardkey" tasten_code="Move">
+		<RemoteMidi index="34" note="36" channel="3" type="hardkey" tasten_code="Move">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="36" note="57" channel="3" type="hardkey" tasten_code="0">
+		<RemoteMidi index="36" note="59" channel="3" type="hardkey" tasten_code="0">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="37" note="51" channel="3" type="hardkey" tasten_code="1">
+		<RemoteMidi index="37" note="52" channel="3" type="hardkey" tasten_code="1">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="38" note="52" channel="3" type="hardkey" tasten_code="2">
+		<RemoteMidi index="38" note="53" channel="3" type="hardkey" tasten_code="2">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="39" note="53" channel="3" type="hardkey" tasten_code="3">
+		<RemoteMidi index="39" note="54" channel="3" type="hardkey" tasten_code="3">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="40" note="47" channel="3" type="hardkey" tasten_code="4">
+		<RemoteMidi index="40" note="48" channel="3" type="hardkey" tasten_code="4">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="41" note="48" channel="3" type="hardkey" tasten_code="5">
+		<RemoteMidi index="41" note="49" channel="3" type="hardkey" tasten_code="5">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="42" note="49" channel="3" type="hardkey" tasten_code="6">
+		<RemoteMidi index="42" note="50" channel="3" type="hardkey" tasten_code="6">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="43" note="38" channel="3" type="hardkey" tasten_code="7">
+		<RemoteMidi index="43" note="39" channel="3" type="hardkey" tasten_code="7">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="44" note="39" channel="3" type="hardkey" tasten_code="8">
+		<RemoteMidi index="44" note="40" channel="3" type="hardkey" tasten_code="8">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="45" note="40" channel="3" type="hardkey" tasten_code="9">
+		<RemoteMidi index="45" note="41" channel="3" type="hardkey" tasten_code="9">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="46" note="41" channel="3" type="hardkey" tasten_code="Plus">
+		<RemoteMidi index="46" note="42" channel="3" type="hardkey" tasten_code="Plus">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<!-- <RemoteMidi index="47" note="60" channel="3" type="hardkey" tasten_code="Minus">
-			<InfoItems>
-				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
-			</InfoItems>
-		</RemoteMidi> -->
-		<RemoteMidi index="48" note="58" channel="3" type="hardkey" tasten_code="Dot">
+		<RemoteMidi index="47" note="55" channel="3" type="hardkey" tasten_code="Minus">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="49" note="42" channel="3" type="hardkey" tasten_code="Full">
+		<RemoteMidi index="48" note="60" channel="3" type="hardkey" tasten_code="Dot">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="50" note="43" channel="3" type="hardkey" tasten_code="Highlight">
+		<RemoteMidi index="49" note="43" channel="3" type="hardkey" tasten_code="Full">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="51" note="44" channel="3" type="hardkey" tasten_code="Solo">
+		<RemoteMidi index="50" note="44" channel="3" type="hardkey" tasten_code="Highlight">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="52" note="50" channel="3" type="hardkey" tasten_code="Thru">
+		<RemoteMidi index="51" note="45" channel="3" type="hardkey" tasten_code="Solo">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="53" note="59" channel="3" type="hardkey" tasten_code="If">
+		<RemoteMidi index="52" note="51" channel="3" type="hardkey" tasten_code="Thru">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="54" note="60" channel="3" type="hardkey" tasten_code="At">
+		<RemoteMidi index="53" note="61" channel="3" type="hardkey" tasten_code="If">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="55" note="56" channel="3" type="hardkey" tasten_code="Clear">
+		<RemoteMidi index="54" note="62" channel="3" type="hardkey" tasten_code="At">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="56" note="66" channel="3" type="hardkey" tasten_code="Please">
+		<RemoteMidi index="55" note="58" channel="3" type="hardkey" tasten_code="Clear">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="57" note="54" channel="3" type="hardkey" tasten_code="Up">
+		<RemoteMidi index="56" note="68" channel="3" type="hardkey" tasten_code="Please">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="58" note="67" channel="3" type="hardkey" tasten_code="Down">
+		<RemoteMidi index="57" note="56" channel="3" type="hardkey" tasten_code="Up">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="59" note="62" channel="3" type="hardkey" tasten_code="Set">
+		<RemoteMidi index="58" note="69" channel="3" type="hardkey" tasten_code="Down">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="60" note="61" channel="3" type="hardkey" tasten_code="Previous">
+		<RemoteMidi index="59" note="64" channel="3" type="hardkey" tasten_code="Set">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="61" note="63" channel="3" type="hardkey" tasten_code="Next">
+		<RemoteMidi index="60" note="63" channel="3" type="hardkey" tasten_code="Previous">
+			<InfoItems>
+				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
+			</InfoItems>
+		</RemoteMidi>
+		<RemoteMidi index="61" note="65" channel="3" type="hardkey" tasten_code="Next">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
@@ -312,7 +312,7 @@
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="64" channel="1" type="hardkey" tasten_code="Tools">
+		<RemoteMidi index="64" note="1" channel="3" type="hardkey" tasten_code="Tools">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
@@ -337,17 +337,12 @@
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="69" note="37" channel="3" type="hardkey" tasten_code="Escape">
+		<RemoteMidi index="69" note="38" channel="3" type="hardkey" tasten_code="Escape">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>
 		</RemoteMidi>
-		<RemoteMidi index="70" note="1" channel="3" type="hardkey" tasten_code="Escape">
-			<InfoItems>
-				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
-			</InfoItems>
-		</RemoteMidi>
-		<RemoteMidi index="71" note="4" channel="3" type="hardkey" tasten_code="Tools">
+		<RemoteMidi index="70" note="31" channel="3" type="hardkey" tasten_code="Pause">
 			<InfoItems>
 				<Info date="2023-08-23T00:00:00">MA2 Keyboard project</Info>
 			</InfoItems>


### PR DESCRIPTION
Your table in the README did not match what the code said. It was missing 2 keys causing most of the midi mappings to be off by 1 or 2. I updated it to have all the keys and they're proper note mapping.

I have also added a mapping file that can be imported directly into MA2 for easier setup in showfiles. It does setup to channel 3 right now but that can be changed in MA2 once imported.

I think this is an awesome project and I am hoping to make one myself in the near future. But in the meantime, this update should help others that are currently building one :slightly_smiling_face: 